### PR TITLE
feat: allow s3 credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,9 +88,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-credential-types"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1317e1a3514b103cf7d5828bbab3b4d30f56bd22d684f8568bc51b6cfbbb1c"
+checksum = "4a7cb3510b95492bd9014b60e2e3bee3e48bc516e220316f8e6b60df18b47331"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361c4310fdce94328cc2d1ca0c8a48c13f43009c61d3367585685a50ca8c66b6"
+checksum = "a95d41abe4e941399fdb4bc2f54713eac3c839d98151875948bb24e66ab658f2"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed7ef604a15fd0d4d9e43701295161ea6b504b63c44990ead352afea2bc15e9"
+checksum = "233cca219c6705d525ace011d6f9bc51aaf32fce5b4c41661d2d7ff22d9b4d49"
 dependencies = [
  "aws-credential-types",
  "aws-http",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.4.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcafc2fe52cc30b2d56685e2fa6a879ba50d79704594852112337a472ddbd24"
+checksum = "634fbe5b6591ee2e281cd2ba8641e9bd752dbf5bf338924d6ad4bd5a3304fe31"
 dependencies = [
  "aws-credential-types",
  "aws-http",
@@ -161,16 +161,16 @@ dependencies = [
  "http-body 0.4.5",
  "once_cell",
  "percent-encoding",
- "regex",
+ "regex-lite",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380adcc8134ad8bbdfeb2ace7626a869914ee266322965276cbc54066186d236"
+checksum = "b92384b39aedb258aa734fe0e7b2ffcd13f33e68227251a72cd2635e0acc8f1a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -186,7 +186,6 @@ dependencies = [
  "once_cell",
  "p256",
  "percent-encoding",
- "regex",
  "ring",
  "sha2",
  "subtle",
@@ -197,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.0.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e37ca17d25fe1e210b6d4bdf59b81caebfe99f986201a1228cb5061233b4b13"
+checksum = "71d8e1c0904f78c76846a9dad41c28b41d330d97741c3e70d003d9a747d95e2a"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -208,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a373ec01aede3dd066ec018c1bc4e8f5dd11b2c11c59c8eef1a5c68101f397"
+checksum = "62d59ef74bf94562512e570eeccb81e9b3879f9136b2171ed4bf996ffa609955"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -229,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c669e1e5fc0d79561bf7a122b118bd50c898758354fe2c53eb8f2d31507cbc3"
+checksum = "31cf0466890a20988b9b2864250dd907f769bd189af1a51ba67beec86f7669fb"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -240,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1de8aee22f67de467b2e3d0dd0fb30859dc53f579a63bd5381766b987db644"
+checksum = "568a3b159001358dd96143378afd7470e19baffb6918e4b5016abe576e553f9c"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -261,18 +260,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a46dd338dc9576d6a6a5b5a19bd678dcad018ececee11cf28ecd7588bd1a55c"
+checksum = "f12bfb23370a069f8facbfd53ce78213461b0a8570f6c81488030f5ab6f8cc4e"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.0.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273479291efc55e7b0bce985b139d86b6031adb8e50f65c1f712f20ba38f6388"
+checksum = "7cf0f6845d2d97b953cea791b0ee37191c5509f2897ec7eb7580a0e7a594e98b"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -295,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.0.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cebff0d977b6b6feed2fd07db52aac58ba3ccaf26cdd49f1af4add5061bef9"
+checksum = "47798ba97a33979c80e837519cf837f18fd6df0adb02dd5286a75d9891c6e671"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -310,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.0.2"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f48b3f27ddb40ab19892a5abda331f403e3cb877965e4e51171447807104af"
+checksum = "4e9a85eafeaf783b2408e35af599e8b96f2c49d9a5d13ad3a887fbdefb6bc744"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -333,18 +332,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec40d74a67fd395bc3f6b4ccbdf1543672622d905ef3f979689aea5b730cb95"
+checksum = "5a84bee2b44c22cbba59f12c34b831a97df698f8e43df579b35998652a00dc13"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8403fc56b1f3761e8efe45771ddc1165e47ec3417c68e68a4519b5cb030159ca"
+checksum = "8549aa62c5b7db5c57ab915200ee214b4f5d8f19b29a4a8fa0b3ad3bca1380e3"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -1229,6 +1228,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,9 +1638,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1652,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ missing_errors_doc = "allow"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-s3 = { version = "1.4", features = ["behavior-version-latest"] }
-tokio = { version = "1.29", features = ["full"] }
-aws-types = "1.0"
-aws-credential-types = "1.0"
-aws-smithy-runtime-api = "1.0"
+aws-sdk-s3 = { version = "1.12", features = ["behavior-version-latest"] }
+tokio = { version = "1.35", features = ["full"] }
+aws-types = "1.1"
+aws-credential-types = "1.1"
+aws-smithy-runtime-api = "1.1"
 http = "1"
 hyper = "1"
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,20 +11,25 @@ path = "bin/cli.rs"
 name = "root_s3"
 path = "src/lib.rs"
 
+[lints.clippy]
+pedantic = "warn"
+too_many_lines = "allow"
+missing_errors_doc = "allow"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-s3 = { version = "1.4.0", features = ["behavior-version-latest"] }
-tokio = { version = "1.29.1", features = ["full"] }
+aws-sdk-s3 = { version = "1.4", features = ["behavior-version-latest"] }
+tokio = { version = "1.29", features = ["full"] }
 aws-types = "1.0"
 aws-credential-types = "1.0"
-aws-smithy-runtime-api = "1.0.2"
+aws-smithy-runtime-api = "1.0"
 http = "1"
 hyper = "1"
 anyhow = "1.0"
 clap = { version = "4.4", features = ["derive"] }
 env_logger = "0.10"
 log = "0.4"
-bytes = "1.5.0"
-tokio-stream = { version = "0.1.14", features = ["full"] }
-thiserror = "1.0.50"
+bytes = "1.5"
+tokio-stream = { version = "0.1", features = ["full"] }
+thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ path = "src/lib.rs"
 
 [lints.clippy]
 pedantic = "warn"
-too_many_lines = "allow"
 missing_errors_doc = "allow"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/bin/cli.rs
+++ b/bin/cli.rs
@@ -226,9 +226,9 @@ async fn main() -> std::io::Result<()> {
     Ok(())
 }
 
-async fn get_client(args: &S3Cli) -> Result<root_s3::RootS3Client> {
+async fn get_client(args: &S3Cli) -> Result<root_s3::Client> {
     if let Some(api_key) = &args.api_key {
-        Ok(root_s3::RootS3Client::new(
+        Ok(root_s3::Client::new(
             args.url.clone(),
             api_key,
             args.org_id.unwrap_or(0),
@@ -242,7 +242,7 @@ async fn get_client(args: &S3Cli) -> Result<root_s3::RootS3Client> {
             region: "eu".to_string(),
         };
 
-        Ok(root_s3::RootS3Client::new_from_s3_credentials(
+        Ok(root_s3::Client::new_from_s3_credentials(
             args.url.clone(),
             cred,
         )?)

--- a/bin/cli.rs
+++ b/bin/cli.rs
@@ -53,7 +53,7 @@ async fn main() -> std::io::Result<()> {
 
     match args.command {
         SubCommand::CreateBucket(CreateBucketArgs { name }) => {
-            let client = RootS3Client::new(args.url.as_ref(), args.api_key, args.org_id).unwrap();
+            let client = RootS3Client::new(args.url, &*args.api_key, args.org_id).unwrap();
             let res = client.create_bucket(&name, args.project_id).await;
             match res {
                 Ok(_) => println!("Bucket created: {:?}", name),
@@ -61,7 +61,7 @@ async fn main() -> std::io::Result<()> {
             }
         }
         SubCommand::DeleteBucket(DeleteBucketArgs { name }) => {
-            let client = RootS3Client::new(args.url.as_ref(), args.api_key, args.org_id).unwrap();
+            let client = RootS3Client::new(args.url, &*args.api_key, args.org_id).unwrap();
             let res = client.delete_bucket(&name, args.project_id).await;
             match res {
                 Ok(_) => println!("Bucket deleted: {:?}", name),
@@ -69,7 +69,7 @@ async fn main() -> std::io::Result<()> {
             }
         }
         SubCommand::ListBuckets(ListBucketsArgs {}) => {
-            let client = RootS3Client::new(args.url.as_ref(), args.api_key, args.org_id).unwrap();
+            let client = RootS3Client::new(args.url, &*args.api_key, args.org_id).unwrap();
             let res = client.list_buckets(args.project_id).await.unwrap();
 
             debug!("result {:?}", res);
@@ -94,7 +94,7 @@ async fn main() -> std::io::Result<()> {
             file_path,
             metadata,
         }) => {
-            let client = RootS3Client::new(args.url.as_ref(), args.api_key, args.org_id).unwrap();
+            let client = RootS3Client::new(args.url, &*args.api_key, args.org_id).unwrap();
 
             let mut file = File::open(file_path).await?;
 
@@ -136,7 +136,7 @@ async fn main() -> std::io::Result<()> {
             key,
             output,
         }) => {
-            let client = RootS3Client::new(args.url.as_ref(), args.api_key, args.org_id).unwrap();
+            let client = RootS3Client::new(args.url, &*args.api_key, args.org_id).unwrap();
             let res = client.get_object(&bucket, &key, args.project_id).await;
 
             match res {
@@ -162,7 +162,7 @@ async fn main() -> std::io::Result<()> {
             source_bucket,
             source_key,
         }) => {
-            let client = RootS3Client::new(args.url.as_ref(), args.api_key, args.org_id).unwrap();
+            let client = RootS3Client::new(args.url, &*args.api_key, args.org_id).unwrap();
             let res = client
                 .copy_object(&bucket, &key, &source_bucket, &source_key, args.project_id)
                 .await;
@@ -176,7 +176,7 @@ async fn main() -> std::io::Result<()> {
             }
         }
         SubCommand::DeleteObject(DeleteObjectArgs { bucket, key }) => {
-            let client = RootS3Client::new(args.url.as_ref(), args.api_key, args.org_id).unwrap();
+            let client = RootS3Client::new(args.url, &*args.api_key, args.org_id).unwrap();
 
             let res = client.delete_object(&bucket, &key, args.project_id).await;
             match res {
@@ -185,7 +185,7 @@ async fn main() -> std::io::Result<()> {
             }
         }
         SubCommand::ListObjects(ListObjectArgs { bucket }) => {
-            let client = RootS3Client::new(args.url.as_ref(), args.api_key, args.org_id).unwrap();
+            let client = RootS3Client::new(args.url, &*args.api_key, args.org_id).unwrap();
             let res = client.list_objects(&bucket, args.project_id).await.unwrap();
 
             if let Some(contents) = res.contents {
@@ -204,7 +204,7 @@ async fn main() -> std::io::Result<()> {
             }
         }
         SubCommand::GetHeadObject(GetHeadObject { bucket, key }) => {
-            let client = RootS3Client::new(args.url.as_ref(), args.api_key, args.org_id).unwrap();
+            let client = RootS3Client::new(args.url, &*args.api_key, args.org_id).unwrap();
             let res = client
                 .head_object(&bucket, &key, args.project_id)
                 .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,15 @@
 use anyhow::Result;
 use aws_credential_types::{provider::SharedCredentialsProvider, Credentials};
-use aws_sdk_s3::{
-    operation::{
-        copy_object::{CopyObjectError, CopyObjectOutput},
-        create_bucket::{CreateBucketError, CreateBucketOutput},
-        delete_bucket::{DeleteBucketError, DeleteBucketOutput},
-        delete_object::{DeleteObjectError, DeleteObjectOutput},
-        get_object::{GetObjectError, GetObjectOutput},
-        head_object::{HeadObjectError, HeadObjectOutput},
-        list_buckets::{ListBucketsError, ListBucketsOutput},
-        list_objects_v2::{ListObjectsV2Error, ListObjectsV2Output},
-        put_object::{PutObjectError, PutObjectOutput},
-    },
-    Client,
+use aws_sdk_s3::operation::{
+    copy_object::{CopyObjectError, CopyObjectOutput},
+    create_bucket::{CreateBucketError, CreateBucketOutput},
+    delete_bucket::{DeleteBucketError, DeleteBucketOutput},
+    delete_object::{DeleteObjectError, DeleteObjectOutput},
+    get_object::{GetObjectError, GetObjectOutput},
+    head_object::{HeadObjectError, HeadObjectOutput},
+    list_buckets::{ListBucketsError, ListBucketsOutput},
+    list_objects_v2::{ListObjectsV2Error, ListObjectsV2Output},
+    put_object::{PutObjectError, PutObjectOutput},
 };
 use aws_smithy_runtime_api::http::Request;
 use aws_types::{region::Region, sdk_config::SdkConfig};
@@ -21,9 +18,9 @@ use thiserror::Error;
 
 /// RootS3Client struct represents a client for interacting with the S3 service of root.
 #[derive(Debug, Clone)]
-pub struct RootS3Client {
+pub struct Client {
     /// S3 client from AWS SDK.
-    pub s3_client: Client,
+    pub s3_client: aws_sdk_s3::Client,
 
     /// Optional root config.
     pub config: Option<RootConfig>,
@@ -67,7 +64,7 @@ pub struct S3Credentials {
     pub region: String,
 }
 
-impl RootS3Client {
+impl Client {
     /// Creates a new `RootS3Client`.
     ///
     /// # Arguments
@@ -109,7 +106,7 @@ impl RootS3Client {
     }
 }
 
-pub fn get_s3_client(url: &str, credentials: Option<S3Credentials>) -> Result<Client> {
+pub fn get_s3_client(url: &str, credentials: Option<S3Credentials>) -> Result<aws_sdk_s3::Client> {
     let cred = match credentials {
         Some(cred) => Credentials::new(cred.access_key_id, cred.secret_access_key, None, None, ""),
         None => Credentials::new("", "", None, None, ""),
@@ -117,7 +114,7 @@ pub fn get_s3_client(url: &str, credentials: Option<S3Credentials>) -> Result<Cl
 
     let scred = SharedCredentialsProvider::new(cred);
 
-    let client = Client::new(
+    let client = aws_sdk_s3::Client::new(
         &SdkConfig::builder()
             .endpoint_url(url)
             .region(Region::new("eu-central-1"))
@@ -128,7 +125,7 @@ pub fn get_s3_client(url: &str, credentials: Option<S3Credentials>) -> Result<Cl
     Ok(client)
 }
 
-impl RootS3Client {
+impl Client {
     pub async fn create_bucket(
         &self,
         bucket: &str,


### PR DESCRIPTION
Allows generic s3 credentials

If `new_from_s3_credentials` is used, an s3 gateway accepting credentials should be choosen (not root). If using `new` a root api key needs to be provided.